### PR TITLE
Add Archlinux Qt5 inlude paths

### DIFF
--- a/cmake/FindQt5Core.cmake
+++ b/cmake/FindQt5Core.cmake
@@ -16,6 +16,7 @@ find_path(QT5CORE32_INCLUDE_DIR NAMES QtCoreVersion
     /usr/include/qt5/QtCore
     /usr/include
     /usr/include/QtCore
+    /usr/include/qt/QtCore
     )
 find_path(QT5CORE32_BASE_INCLUDE_DIR NAMES QtCore/QtCoreVersion
     PATHS
@@ -25,6 +26,7 @@ find_path(QT5CORE32_BASE_INCLUDE_DIR NAMES QtCore/QtCoreVersion
     ${KDE4_INCLUDE_DIR}
     /usr/include/qt5
     /usr/include
+    /usr/include/qt
     )
 find_library(QT5CORE32_LIBRARIES NAMES Qt5Core libQt5Core PATHS /usr/lib /usr/lib/i386-linux-gnu/)
 SET(QT5CORE32_INCLUDE_DIRS "${QT5CORE32_INCLUDE_DIR};${QT5CORE32_BASE_INCLUDE_DIR}")

--- a/cmake/FindQt5Gui.cmake
+++ b/cmake/FindQt5Gui.cmake
@@ -15,6 +15,7 @@ find_path(QT5GUI32_INCLUDE_DIR NAMES QtGuiVersion
     /usr/include
     /usr/include/QtGui
     /usr/include/qt5/QtGui
+    /usr/include/qt/QtGui
     )
 find_path(QT5GUI32_BASE_INCLUDE_DIR NAMES QtGui/QtGuiVersion
     PATHS
@@ -23,6 +24,7 @@ find_path(QT5GUI32_BASE_INCLUDE_DIR NAMES QtGui/QtGuiVersion
     ${KDE4_INCLUDE_DIR}
     /usr/include
     /usr/include/qt5
+    /usr/include/qt
     )
 find_library(QT5GUI32_LIBRARIES NAMES Qt5Gui libQt5Gui PATHS /usr/lib /usr/lib/i386-linux-gnu/)
 SET(QT5GUI32_INCLUDE_DIRS "${QT5GUI32_INCLUDE_DIR};${QT5GUI32_BASE_INCLUDE_DIR}")

--- a/cmake/FindQt5Widgets.cmake
+++ b/cmake/FindQt5Widgets.cmake
@@ -15,6 +15,7 @@ find_path(QT5WIDGETS32_INCLUDE_DIR NAMES QtWidgetsVersion
     /usr/include
     /usr/include/QtWidgets
     /usr/include/qt5/QtWidgets
+    /usr/include/qt/QtWidgets
     )
 find_path(QT5WIDGETS32_BASE_INCLUDE_DIR NAMES QtWidgets/QtWidgetsVersion
     PATHS
@@ -23,6 +24,7 @@ find_path(QT5WIDGETS32_BASE_INCLUDE_DIR NAMES QtWidgets/QtWidgetsVersion
     ${KDE4_INCLUDE_DIR}
     /usr/include
     /usr/include/qt5
+    /usr/include/qt
     )
 find_library(QT5WIDGETS32_LIBRARIES NAMES Qt5Widgets libQt5Widgets PATHS /usr/lib /usr/lib/i386-linux-gnu/)
 SET(QT5WIDGETS32_INCLUDE_DIRS "${QT5WIDGETS32_INCLUDE_DIR};${QT5WIDGETS32_BASE_INCLUDE_DIR}")

--- a/cmake/FindQt5X11Extras.cmake
+++ b/cmake/FindQt5X11Extras.cmake
@@ -15,6 +15,7 @@ find_path(QT5X11EXTRAS32_INCLUDE_DIR NAMES QtX11ExtrasVersion
     /usr/include
     /usr/include/QtX11Extras
     /usr/include/qt5/QtX11Extras
+    /usr/include/qt/QtX11Extras
     )
 find_path(QT5X11EXTRAS32_BASE_INCLUDE_DIR NAMES QtX11Extras/QtX11ExtrasVersion
     PATHS
@@ -23,6 +24,7 @@ find_path(QT5X11EXTRAS32_BASE_INCLUDE_DIR NAMES QtX11Extras/QtX11ExtrasVersion
     ${KDE4_INCLUDE_DIR}
     /usr/include
     /usr/include/qt5
+    /usr/include/qt
     )
 find_library(QT5X11EXTRAS32_LIBRARIES NAMES Qt5X11Extras libQt5X11Extras libQt5X11Extras.so.5 PATHS /usr/lib /usr/lib/i386-linux-gnu/)
 SET(QT5X11EXTRAS32_INCLUDE_DIRS "${QT5X11EXTRAS32_INCLUDE_DIR};${QT5X11EXTRAS32_BASE_INCLUDE_DIR}")


### PR DESCRIPTION
By default in Archlinux Qt5 installs in /usr/include/qt - [core, gui, widgets](https://www.archlinux.org/packages/extra/i686/qt5-base/files/) and [x11extras](https://www.archlinux.org/packages/extra/i686/qt5-x11extras/files/).
So add this paths in findQT5\* cmake files.
